### PR TITLE
add configuration "arrowIsTwoCharWide"

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "JimmyZJX",
   "displayName": "Leader Key",
   "description": "Leader key with a which-key like menu",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "homepage": "https://github.com/JimmyZJX/leaderkey",
   "repository": {
     "type": "git",
@@ -69,9 +69,14 @@
     "configuration": {
       "title": "leaderkey",
       "properties": {
+        "leaderkey.arrowIsTwoCharWide": {
+          "type": "boolean",
+          "default": false,
+          "description": "Fixes appearence issue for fonts that renders \"→\" as 2-char wide"
+        },
         "leaderkey.overrides.user": {
           "type": "object",
-          "default": {},
+          "default": { },
           "description": "leaderkey user configuration dictionary.\nThe key of the dict is a leaderkey path (e.g. `SPC a f`).\nThe value is usually a command ({command: \"some-command\"}) but could also be a string (as the name of the binding group)"
         }
       }

--- a/src/command.ts
+++ b/src/command.ts
@@ -76,13 +76,6 @@ export function overrideExn(
 
 export type TokenType = "key" | "arrow" | "command" | "binding";
 
-export interface RenderedToken {
-  type: TokenType;
-  line: number;
-  char: number;
-  text: string;
-}
-
 const shiftChars = '~!@#$%^&*()_+<>?{}:"|';
 export const unshiftChars = "`1234567890-=,./[];'\\";
 


### PR DESCRIPTION
closes #1

I've tried to just replace it with `\2192` but that does not seem to be the root cause. Instead, I'll need to change a bit of the code and expose an option to correctly place the right arrow and adjust the layout.

I've tried `Iosevka` and the following setting should fix the issue.
```
"leaderkey.arrowIsTwoCharWide": true,
```