### PR TITLE
Add configurable leaderkey.dired.exe

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ configurations and UI.
 
   <img src="img/ripgrep.png" width="75%">
 
-(Make sure you set "leaderkey.fzf.exe" and "leaderkey.ripgrep.exe")
+(Make sure you set "leaderkey.fzf.exe" and "leaderkey.ripgrep.exe", and for macOS
+install coreutils to set "leaderkey.dired.exe")
 
 It can be considered an alternative implementation to
 [VSpaceCode](https://github.com/VSpaceCode/VSpaceCode) +

--- a/package.json
+++ b/package.json
@@ -167,6 +167,11 @@
           "default": "fzf",
           "description": "path to the fzf executable (recommend 0.62.0 or above)"
         },
+        "leaderkey.dired.exe": {
+          "type": "string",
+          "default": "/bin/ls",
+          "description": "path to the an ls executable that supports --dired (e.g. GNU coreutils on macOS, or ls on Linux)"
+        },
         "leaderkey.find-file.RETisTAB": {
           "type": "boolean",
           "default": false,

--- a/src/findFile/dired.ts
+++ b/src/findFile/dired.ts
@@ -43,8 +43,11 @@ async function loadContent(uri: Uri): Promise<DecoratedPage<DiredMetadata>> {
       },
     };
   }
+
+  const prog = workspace.getConfiguration("leaderkey").get("dired.exe", "/bin/ls");
+
   return await runAndParseAnsi(
-    "/bin/ls",
+    prog,
     // l: long details, A: all but . and .., h: human readable, H: follow link for input
     [
       "-lAhH",


### PR DESCRIPTION
I installed your excellent leaderkey extension on macOS, and was sad to find that your extension always used `/bin/ls` for dired, resulting in output like below:
```
ls: unrecognized option `--dired'

usage: ls [-@ABCFGHILOPRSTUWXabcdefghiklmnopqrstuvwxy1%,] [--color=when] [-D format] [file ...]
```
I wanted to replace this with the GNU coreutils `ls` via `brew install coreutils`, but then needed a way to select that binary instead. To do so, I added it as a property to the configuration similar to `rg` and `fzf`.