### PR TITLE
[chore] make "RemoteCommons" dependency check later

### DIFF
--- a/src/findFile/findFileDataProvider.ts
+++ b/src/findFile/findFileDataProvider.ts
@@ -28,7 +28,9 @@ export function getFileFromDataIdx(data: FindFileData, idx: number) {
 }
 
 async function ls(dir: string, dirOnly: boolean) {
-  const ok = await isRemoteCommonsInstalled();
+  if (!(await isRemoteCommonsInstalled())) {
+    return [];
+  }
   const filesAndDirs = await readDirFilesAndDirs(dir);
   let dirs = filesAndDirs.dirs;
   const dotAndDotDot = ["./", ...(dir.length > 1 ? ["../"] : [])];

--- a/src/findFile/findFileDataProvider.ts
+++ b/src/findFile/findFileDataProvider.ts
@@ -1,6 +1,6 @@
 import globRegex from "glob-regex";
 import { window, workspace } from "vscode";
-import { readDirFilesAndDirs } from "../common/remote";
+import { isRemoteCommonsInstalled, readDirFilesAndDirs } from "../common/remote";
 import { stripSlash } from "../common/stripSlash";
 import { byLengthAsc, byStartAsc, Fzf } from "../fzf-for-js/src/lib/main";
 import { FzfResultItem } from "../fzf-for-js/src/lib/types";
@@ -28,6 +28,7 @@ export function getFileFromDataIdx(data: FindFileData, idx: number) {
 }
 
 async function ls(dir: string, dirOnly: boolean) {
+  const ok = await isRemoteCommonsInstalled();
   const filesAndDirs = await readDirFilesAndDirs(dir);
   let dirs = filesAndDirs.dirs;
   const dotAndDotDot = ["./", ...(dir.length > 1 ? ["../"] : [])];

--- a/src/findFile/fzfProcess.ts
+++ b/src/findFile/fzfProcess.ts
@@ -1,6 +1,11 @@
 import { window, workspace } from "vscode";
 import { log } from "../common/global";
-import { fetchText, isWin, runProcess } from "../common/remote";
+import {
+  isRemoteCommonsInstalled,
+  fetchText,
+  isWin,
+  runProcess,
+} from "../common/remote";
 import { stripSlash } from "../common/stripSlash";
 
 type FzfState =
@@ -77,6 +82,9 @@ export class FzfProcess {
 
     const fzfExe = workspace.getConfiguration("leaderkey").get<string>("fzf.exe", "fzf");
     this.state = new Promise(async (resolveState) => {
+      if (!(await isRemoteCommonsInstalled())) {
+        return;
+      }
       const resolve = (s: FzfState) => {
         log(`fzf state -> ${JSON.stringify(s)}`);
         this.stateResolved = s;

--- a/src/findFile/fzfProcess.ts
+++ b/src/findFile/fzfProcess.ts
@@ -82,9 +82,6 @@ export class FzfProcess {
 
     const fzfExe = workspace.getConfiguration("leaderkey").get<string>("fzf.exe", "fzf");
     this.state = new Promise(async (resolveState) => {
-      if (!(await isRemoteCommonsInstalled())) {
-        return;
-      }
       const resolve = (s: FzfState) => {
         log(`fzf state -> ${JSON.stringify(s)}`);
         this.stateResolved = s;
@@ -100,6 +97,10 @@ export class FzfProcess {
         code: 0,
         detail: "fzf not initialized",
       };
+      if (!(await isRemoteCommonsInstalled())) {
+        resolve(lastResp);
+        return;
+      }
       for (let j = 0; j < 5; j++) {
         // try to spawn fzf up to 5 times
         const port = getRandomDynamicPort();

--- a/src/ripgrep/rg.ts
+++ b/src/ripgrep/rg.ts
@@ -1,7 +1,11 @@
 import { relative } from "path-browserify";
 import { CancellationToken, Uri, workspace } from "vscode";
 import { log } from "../common/global";
-import { normalizePath, ProcessLineStreamer } from "../common/remote";
+import {
+  isRemoteCommonsInstalled,
+  normalizePath,
+  ProcessLineStreamer,
+} from "../common/remote";
 import { magicSpace, matchMagic, parseMagicQuery } from "./magicQuery";
 
 //#region ripgrep message format (incomplete)
@@ -100,6 +104,9 @@ export async function doQuery(
   onUpdate: (update: RipgrepStatusUpdate) => void,
   cancellationToken: CancellationToken,
 ) {
+  if (!(await isRemoteCommonsInstalled())) {
+    return;
+  }
   const { prog, args, cwd, magicSpaceRegExp } = toArgs(query);
   const proc = new ProcessLineStreamer(prog, args, { cwd });
 


### PR DESCRIPTION
#14 This may avoid poping up tips to install `RemoteCommons` when initializing